### PR TITLE
Fix executing vmdebootstrap command when not using sudo

### DIFF
--- a/emulation_configure.bash
+++ b/emulation_configure.bash
@@ -247,7 +247,7 @@ function manifest_template_image() {
 
     # Does this vintage of vmdeboostrap eat "variant" or "debootstrapopts"?
 
-    $VMD --dump-config | grep -q '^variant ='
+    eval $VMD --dump-config | grep -q '^variant ='
     if [ $? -eq 0 ]; then
     	VAROPT='--variant=buildd'
     else


### PR DESCRIPTION
The vmdeboostrap command is build up in a string variable.
It normally would invoke the sudo command at first,
but when you run the script directly as root the $SUDO variable is empty.
Then the command begins with a variable declaration. This will result in the following error:

``` bash
  ./emulation_configure.bash: line 250: http_proxy=: command not found
```

Prefixed variable declaration will not work in bash in this case.
You have to use the builtin `eval`.
