### PR TITLE
fabric_emulation.bash should honor TMPDIR

### DIFF
--- a/emulation_configure.bash
+++ b/emulation_configure.bash
@@ -398,7 +398,7 @@ EODOIT
 	echo "	-netdev bridge,id=$NETWORK,br=$NETWORK,helper=$QBH \\"
 	echo "	-device virtio-net,mac=$MAC,netdev=$NETWORK \\"
 	echo "	-device ivshmem,shm=$PROJECT,size=1024 \\"
-	echo "	\$NODISPLAY /tmp/$NODE.qcow2 &"
+	echo "	\$NODISPLAY $TMPDIR/$NODE.qcow2 &"
 	echo
     done
     exec 1>&3		# Restore stdout


### PR DESCRIPTION
the generated `fabric_emulation.bash` contains hardcoded paths to `/tmp/fabric*.qcow2`. 
Instead, it should use the directory set in `$TMPDIR` during invocation of `emulation_configure.bash`.

The change is trivial, really, but necessary for the generated script to work.

Thanks =)
