### PR TITLE
FAME_SIZE check has mismatch with error log

### DIFF
--- a/emulation_configure.bash
+++ b/emulation_configure.bash
@@ -174,7 +174,7 @@ function verify_host_environment() {
     let TMP=$T/1024/1024/1024
     export FAME_SIZE=${TMP}G
     quiet echo "$FAME_FAM = $FAME_SIZE"
-    [ $TMP -lt 4 ] && die "$FAME_FAM is less than 1G"
+    [ $TMP -lt 1 ] && die "$FAME_FAM is less than 1G"
     [ $TMP -gt 256 ] && echo "$FAME_FAM is greater than 256G"	# QEMU limit
 
     LOOPS=`$SUDO losetup -al | wc -l`


### PR DESCRIPTION
It was comparing with 4G but reporting based on 1G.
Actually, I don't know it supposes to compare size with 4 or 1, but I guess it could be 1G and there is no limitation about that.