### PR TITLE
Use CPU host-passthrough to avoid hardcoding CPU model

### DIFF
--- a/node_template.xml
+++ b/node_template.xml
@@ -15,8 +15,8 @@
     <apic/>
     <pae/>
   </features>
-  <cpu mode='custom' match='exact'>
-    <model fallback='allow'>SandyBridge</model>
+  <cpu>
+    <mode name='host-passthrough' supported='yes'/>
   </cpu>
   <clock offset='utc'>
     <timer name='rtc' tickpolicy='catchup'/>


### PR DESCRIPTION
I needed to apply this patch to start the VMs on an older system after running into some of the problems on #17.

Trying to start the VMs on a non-SandyBridge system pops up various errors to do with unsupported CPU features and flags.